### PR TITLE
git: Use RefString types for git::refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "colored",
  "crossbeam-channel",
  "fastrand",
+ "git-ref-format",
  "lexopt",
  "log",
  "nakamoto-net",
@@ -839,6 +840,7 @@ name = "radicle-tools"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "git-ref-format",
  "radicle",
 ]
 

--- a/radicle-node/Cargo.toml
+++ b/radicle-node/Cargo.toml
@@ -7,19 +7,20 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1" }
-byteorder = { version = "1" }
 bloomy = { version = "1.2" }
+byteorder = { version = "1" }
 chrono = { version = "0.4.0" }
 colored = { version = "1.9.0" }
 crossbeam-channel = { version = "0.5.6" }
 fastrand = { version = "1.8.0" }
+git-ref-format = { version = "0", features = ["serde", "macro"] }
 lexopt = { version = "0.2.1" }
 log = { version = "0.4.17", features = ["std"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
-nonempty = { version = "0.8.0", features = ["serialize"] }
 nakamoto-net = { version = "0.3.0" }
 nakamoto-net-poll = { version = "0.3.0" }
+nonempty = { version = "0.8.0", features = ["serialize"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
 tempfile = { version = "3.3.0" }
 thiserror = { version = "1" }
 

--- a/radicle-node/src/test/tests.rs
+++ b/radicle-node/src/test/tests.rs
@@ -22,7 +22,7 @@ use crate::test::simulator;
 use crate::test::simulator::{Peer as _, Simulation};
 use crate::test::storage::MockStorage;
 use crate::LocalTime;
-use crate::{client, identity, rad, service, storage, test};
+use crate::{client, git, identity, rad, service, test};
 
 // NOTE
 //
@@ -397,7 +397,7 @@ fn test_push_and_pull() {
         &repo,
         "alice",
         "alice's repo",
-        storage::BranchName::from("master"),
+        git::refname!("master"),
         alice.signer(),
         alice.storage(),
     )

--- a/radicle-tools/Cargo.toml
+++ b/radicle-tools/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1" }
+git-ref-format = { version = "0", features = ["serde", "macro"] }
 
 [dependencies.radicle]
 version = "0"

--- a/radicle-tools/src/rad-init.rs
+++ b/radicle-tools/src/rad-init.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use radicle::git;
+
 fn main() -> anyhow::Result<()> {
     let cwd = Path::new(".").canonicalize()?;
     let name = cwd.file_name().unwrap().to_string_lossy().to_string();
@@ -9,7 +11,7 @@ fn main() -> anyhow::Result<()> {
         &repo,
         &name,
         "",
-        radicle::git::BranchName::from("master"),
+        git::refname!("master"),
         &profile.signer,
         &profile.storage,
     )?;

--- a/radicle/src/identity/project.rs
+++ b/radicle/src/identity/project.rs
@@ -71,8 +71,8 @@ impl From<Delegate> for PublicKey {
 #[serde(rename_all = "kebab-case")]
 pub struct Payload {
     pub name: String,
-    pub description: String,    // TODO: Make optional.
-    pub default_branch: String, // TODO: Make optional.
+    pub description: String,            // TODO: Make optional.
+    pub default_branch: git::RefString, // TODO: Make optional.
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/radicle/src/storage.rs
+++ b/radicle/src/storage.rs
@@ -24,7 +24,7 @@ use crate::storage::refs::Refs;
 
 use self::refs::SignedRefs;
 
-pub type BranchName = String;
+pub type BranchName = git::RefString;
 pub type Inventory = Vec<Id>;
 
 /// Storage error.

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -810,7 +810,7 @@ mod tests {
             &source,
             "radicle",
             "radicle",
-            BranchName::from("master"),
+            git::refname!("master"),
             signer,
             &storage,
         )

--- a/radicle/src/test/arbitrary.rs
+++ b/radicle/src/test/arbitrary.rs
@@ -85,7 +85,7 @@ impl Arbitrary for Doc<Unverified> {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
         let name = String::arbitrary(g);
         let description = String::arbitrary(g);
-        let default_branch = String::arbitrary(g);
+        let default_branch = git::RefString::try_from(String::arbitrary(g)).unwrap();
         let delegate = Delegate::arbitrary(g);
 
         Self::initial(name, description, default_branch, delegate)
@@ -101,9 +101,11 @@ impl Arbitrary for Doc<Verified> {
         let description = iter::repeat_with(|| rng.alphanumeric())
             .take(rng.usize(0..32))
             .collect();
-        let default_branch = iter::repeat_with(|| rng.alphanumeric())
+        let default_branch: git::RefString = iter::repeat_with(|| rng.alphanumeric())
             .take(rng.usize(1..16))
-            .collect();
+            .collect::<String>()
+            .try_into()
+            .unwrap();
         let delegates: NonEmpty<_> = iter::repeat_with(|| Delegate {
             name: iter::repeat_with(|| rng.alphanumeric())
                 .take(rng.usize(1..16))

--- a/radicle/src/test/fixtures.rs
+++ b/radicle/src/test/fixtures.rs
@@ -6,7 +6,7 @@ use crate::identity::Id;
 use crate::rad;
 use crate::storage::git::Storage;
 use crate::storage::refs::SignedRefs;
-use crate::storage::{BranchName, WriteStorage};
+use crate::storage::WriteStorage;
 
 /// Create a new storage with a project.
 pub fn storage<P: AsRef<Path>, G: Signer>(path: P, signer: G) -> Result<Storage, rad::InitError> {
@@ -23,7 +23,7 @@ pub fn storage<P: AsRef<Path>, G: Signer>(path: P, signer: G) -> Result<Storage,
             &repo,
             name,
             desc,
-            BranchName::from("master"),
+            git::refname!("master"),
             &signer,
             &storage,
         )?;
@@ -43,7 +43,7 @@ pub fn project<P: AsRef<Path>, S: WriteStorage, G: Signer>(
         &repo,
         "acme",
         "Acme's repository",
-        BranchName::from("master"),
+        git::refname!("master"),
         signer,
         storage,
     )?;


### PR DESCRIPTION
Lean on rust's type system to improve safety.